### PR TITLE
CTECH-3342: make non-required properties default to null

### DIFF
--- a/generate/templates/modelGeneric.mustache
+++ b/generate/templates/modelGeneric.mustache
@@ -134,7 +134,7 @@
     {{#hasOnlyReadOnly}}
         [JsonConstructorAttribute]
     {{/hasOnlyReadOnly}}
-        public {{classname}}({{#readWriteVars}}{{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}}{{/isEnum}} {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = {{#defaultValue}}{{^isDateTime}}{{#isString}}{{#isEnum}}default({{{datatypeWithEnum}}}){{/isEnum}}{{^isEnum}}@{{{defaultValue}}}{{/isEnum}}{{/isString}}{{/isDateTime}}{{#isDateTime}}default({{{datatypeWithEnum}}}){{/isDateTime}}{{/defaultValue}}{{^defaultValue}}default({{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}}{{/isEnum}}){{/defaultValue}}{{^-last}}, {{/-last}}{{/readWriteVars}}){{#parent}} : base({{#parentVars}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{^-last}}, {{/-last}}{{/parentVars}}){{/parent}}
+        public {{classname}}({{#readWriteVars}}{{{datatypeWithEnum}}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}} {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = {{#defaultValue}}{{^isDateTime}}{{#isString}}{{#isEnum}}default({{{datatypeWithEnum}}}){{/isEnum}}{{^isEnum}}@{{{defaultValue}}}{{/isEnum}}{{/isString}}{{/isDateTime}}{{#isDateTime}}default({{{datatypeWithEnum}}}){{/isDateTime}}{{/defaultValue}}{{^defaultValue}}default({{{datatypeWithEnum}}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}}){{/defaultValue}}{{^-last}}, {{/-last}}{{/readWriteVars}}){{#parent}} : base({{#parentVars}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{^-last}}, {{/-last}}{{/parentVars}}){{/parent}}
         {
             {{#vars}}
             {{^isInherited}}


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue

Any non-required property of a model that isn't a container is made nullable, and if it doesn't have a default value defined in the swagger, the default is set to null.