### PR TITLE
fix: Fixes a catastrophic error on Windows Azure Functions when setting the socket options

### DIFF
--- a/generate/templates/ApiClient.mustache
+++ b/generate/templates/ApiClient.mustache
@@ -814,11 +814,16 @@ namespace {{packageName}}.Client
                     {
                         s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                         s.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, true);
-                        s.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 30);
-                        s.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 30);
-                        // note that 100 below gives us 50m worth of tcpkeepalive.  That should be plenty for any call.
-                        // note this doesnt work on some windows versions
-                        s.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, 100);
+
+                        // we did have the interval and keepalivetime set at 30 a piece and the following line to 
+                        // set the number of retries, giving us a total of 50m.
+                        // s.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, 100);
+                        // However as stated originally, that line doesn't work on some windows versions, and
+                        // as it turns out, specifically doesn't work on Windows versions of Azure Functions, so 
+                        // isn't appropriate here. Instead, increasing both 30s keepalives to 300s achieves the same
+                        // 50m threshold without blowing up Azure Functions, so I think we're good.
+                        s.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 300);
+                        s.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 300);
 
                         var addresses = await Dns.GetHostAddressesAsync(ctx.DnsEndPoint.Host);
                         var endpoint = new IPEndPoint(addresses[0], ctx.DnsEndPoint.Port);
@@ -827,6 +832,8 @@ namespace {{packageName}}.Client
                     }
                     catch (Exception e)
                     {
+                        // if we make it in here, there's a pretty good chance we've hit a DNS lookup error.  Not much to be done
+                        // other than rethrow.
                         s.Dispose();
 
                         if (Environment.GetEnvironmentVariable("SDK_LOGGING") != null)


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Was getting
```
Socket Callback error - Creating new stream: System.Net.Sockets.SocketException (10042): An unknown, invalid, or unsupported option or level was specified in a getsockopt or setsockopt call. at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, String callerName) at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Int32 optionValue, Boolean silent) at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Int32 optionValue) at af_mvr.TestClient.<GetHttpClient>b__3_0(SocketsHttpConnectionContext ctx, CancellationToken ct) in /src/tmp/af-mvr/TestClient.cs:line 49
```
when running in Azure Functions that targeted WindowsOS.  This fix removes the potential for that error; at least as it stands today, while retaining the current functionality.

This change is mostly comments to explain what is going on and why.

