### PR TITLE
fix: Updates RestSharp version. Fixes config merge with global config

### DIFF
--- a/generate/default_templates/ApiClient.mustache
+++ b/generate/default_templates/ApiClient.mustache
@@ -1,0 +1,601 @@
+{{>partial_header}}
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.IO;
+using System.Threading;
+{{^netStandard}}
+{{^supportsUWP}}
+using System.Web;
+{{/supportsUWP}}
+{{/netStandard}}
+using System.Linq;
+using System.Net;
+using System.Text;
+using Newtonsoft.Json;
+{{#netStandard}}
+using RestSharp.Portable;
+using RestSharp.Portable.HttpClient;
+{{/netStandard}}
+{{^netStandard}}
+using RestSharp;
+{{/netStandard}}
+
+namespace {{packageName}}.Client
+{
+    /// <summary>
+    /// API client is mainly responsible for making the HTTP call to the API backend.
+    /// </summary>
+    {{>visibility}} partial class ApiClient
+    {
+        public JsonSerializerSettings serializerSettings = new JsonSerializerSettings
+        {
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor
+        };
+
+        /// <summary>
+        /// Allows for extending request processing for <see cref="ApiClient"/> generated code.
+        /// </summary>
+        /// <param name="request">The RestSharp request object</param>
+        partial void InterceptRequest(IRestRequest request);
+
+        /// <summary>
+        /// Allows for extending response processing for <see cref="ApiClient"/> generated code.
+        /// </summary>
+        /// <param name="request">The RestSharp request object</param>
+        /// <param name="response">The RestSharp response object</param>
+        partial void InterceptResponse(IRestRequest request, IRestResponse response);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiClient" /> class
+        /// with default configuration.
+        /// </summary>
+        public ApiClient()
+        {
+            Configuration = {{packageName}}.Client.Configuration.Default;
+            RestClient = new RestClient("{{{basePath}}}");
+            {{#netStandard}}
+            RestClient.IgnoreResponseStatusCode = true;
+            {{/netStandard}}
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiClient" /> class
+        /// with default base path ({{{basePath}}}).
+        /// </summary>
+        /// <param name="config">An instance of Configuration.</param>
+        public ApiClient(Configuration config)
+        {
+            Configuration = config ?? {{packageName}}.Client.Configuration.Default;
+
+            RestClient = new RestClient(Configuration.BasePath);
+            {{#netStandard}}
+            RestClient.IgnoreResponseStatusCode = true;
+            {{/netStandard}}
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiClient" /> class
+        /// with default configuration.
+        /// </summary>
+        /// <param name="basePath">The base path.</param>
+        public ApiClient(String basePath = "{{{basePath}}}")
+        {
+           if (String.IsNullOrEmpty(basePath))
+                throw new ArgumentException("basePath cannot be empty");
+
+            RestClient = new RestClient(basePath);
+            {{#netStandard}}
+            RestClient.IgnoreResponseStatusCode = true;
+            {{/netStandard}}
+            Configuration = Client.Configuration.Default;
+        }
+
+        /// <summary>
+        /// Gets or sets the default API client for making HTTP calls.
+        /// </summary>
+        /// <value>The default API client.</value>
+        [Obsolete("ApiClient.Default is deprecated, please use 'Configuration.Default.ApiClient' instead.")]
+        public static ApiClient Default;
+
+        /// <summary>
+        /// Gets or sets an instance of the IReadableConfiguration.
+        /// </summary>
+        /// <value>An instance of the IReadableConfiguration.</value>
+        /// <remarks>
+        /// <see cref="IReadableConfiguration"/> helps us to avoid modifying possibly global
+        /// configuration values from within a given client. It does not guarantee thread-safety
+        /// of the <see cref="Configuration"/> instance in any way.
+        /// </remarks>
+        public IReadableConfiguration Configuration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the RestClient.
+        /// </summary>
+        /// <value>An instance of the RestClient</value>
+        public RestClient RestClient { get; set; }
+
+        // Creates and sets up a RestRequest prior to a call.
+        private RestRequest PrepareRequest(
+            String path, {{^netStandard}}RestSharp.{{/netStandard}}Method method, List<KeyValuePair<String, String>> queryParams, Object postBody,
+            Dictionary<String, String> headerParams, Dictionary<String, String> formParams,
+            Dictionary<String, FileParameter> fileParams, Dictionary<String, String> pathParams,
+            String contentType)
+        {
+            var request = new RestRequest(path, method);
+            {{#netStandard}}
+            // disable ResetSharp.Portable built-in serialization
+            request.Serializer = null;
+            {{/netStandard}}
+
+            // add path parameter, if any
+            foreach(var param in pathParams)
+                request.AddParameter(param.Key, param.Value, ParameterType.UrlSegment);
+
+            // add header parameter, if any
+            foreach(var param in headerParams)
+                request.AddHeader(param.Key, param.Value);
+
+            // add query parameter, if any
+            foreach(var param in queryParams)
+                request.AddQueryParameter(param.Key, param.Value);
+
+            // add form parameter, if any
+            foreach(var param in formParams)
+                request.AddParameter(param.Key, param.Value);
+
+            // add file parameter, if any
+            foreach(var param in fileParams)
+            {
+                {{#netStandard}}
+                request.AddFile(param.Value);
+                {{/netStandard}}
+                {{^netStandard}}
+                {{^supportsUWP}}
+                request.AddFile(param.Value.Name, param.Value.Writer, param.Value.FileName{{#isRestSharp_106_10_1_above}}, param.Value.ContentLength{{/isRestSharp_106_10_1_above}}, param.Value.ContentType);
+                {{/supportsUWP}}
+                {{#supportsUWP}}
+                byte[] paramWriter = null;
+                param.Value.Writer = delegate (Stream stream) { paramWriter = ToByteArray(stream); };
+                request.AddFile(param.Value.Name, paramWriter, param.Value.FileName, param.Value.ContentType);
+                {{/supportsUWP}}
+                {{/netStandard}}
+            }
+
+            if (postBody != null) // http body (model or byte[]) parameter
+            {
+                {{#netStandard}}
+                request.AddParameter(new Parameter { Value = postBody, Type = ParameterType.RequestBody, ContentType = contentType });
+                {{/netStandard}}
+                {{^netStandard}}
+                request.AddParameter(contentType, postBody, ParameterType.RequestBody);
+                {{/netStandard}}
+            }
+
+            return request;
+        }
+
+        /// <summary>
+        /// Makes the HTTP request (Sync).
+        /// </summary>
+        /// <param name="path">URL path.</param>
+        /// <param name="method">HTTP method.</param>
+        /// <param name="queryParams">Query parameters.</param>
+        /// <param name="postBody">HTTP body (POST request).</param>
+        /// <param name="headerParams">Header parameters.</param>
+        /// <param name="formParams">Form parameters.</param>
+        /// <param name="fileParams">File parameters.</param>
+        /// <param name="pathParams">Path parameters.</param>
+        /// <param name="contentType">Content Type of the request</param>
+        /// <returns>Object</returns>
+        public Object CallApi(
+            String path, {{^netStandard}}RestSharp.{{/netStandard}}Method method, List<KeyValuePair<String, String>> queryParams, Object postBody,
+            Dictionary<String, String> headerParams, Dictionary<String, String> formParams,
+            Dictionary<String, FileParameter> fileParams, Dictionary<String, String> pathParams,
+            String contentType)
+        {
+            var request = PrepareRequest(
+                path, method, queryParams, postBody, headerParams, formParams, fileParams,
+                pathParams, contentType);
+
+            // set timeout
+            {{#netStandard}}RestClient.Timeout = TimeSpan.FromMilliseconds(Configuration.Timeout);{{/netStandard}}
+            {{^netStandard}}RestClient.Timeout = Configuration.Timeout;{{/netStandard}}
+            // set user agent
+            RestClient.UserAgent = Configuration.UserAgent;
+
+            InterceptRequest(request);
+            {{#netStandard}}
+            var response = RestClient.Execute(request).Result;
+            {{/netStandard}}
+            {{^netStandard}}
+            {{^supportsUWP}}
+            var response = RestClient.Execute(request);
+            {{/supportsUWP}}
+            {{#supportsUWP}}
+            // Using async method to perform sync call (uwp-only)
+            var response = RestClient.ExecuteTaskAsync(request).Result;
+            {{/supportsUWP}}
+            {{/netStandard}}
+            InterceptResponse(request, response);
+
+            return (Object) response;
+        }
+        {{#supportsAsync}}
+        /// <summary>
+        /// Makes the asynchronous HTTP request.
+        /// </summary>
+        /// <param name="path">URL path.</param>
+        /// <param name="method">HTTP method.</param>
+        /// <param name="queryParams">Query parameters.</param>
+        /// <param name="postBody">HTTP body (POST request).</param>
+        /// <param name="headerParams">Header parameters.</param>
+        /// <param name="formParams">Form parameters.</param>
+        /// <param name="fileParams">File parameters.</param>
+        /// <param name="pathParams">Path parameters.</param>
+        /// <param name="contentType">Content type.</param>
+        /// <param name="cancellationToken">Cancellation Token.</param>
+        /// <returns>The Task instance.</returns>
+        public async System.Threading.Tasks.Task<Object> CallApiAsync(
+            String path, {{^netStandard}}RestSharp.{{/netStandard}}Method method, List<KeyValuePair<String, String>> queryParams, Object postBody,
+            Dictionary<String, String> headerParams, Dictionary<String, String> formParams,
+            Dictionary<String, FileParameter> fileParams, Dictionary<String, String> pathParams,
+            String contentType, CancellationToken cancellationToken)
+        {
+            var request = PrepareRequest(
+                path, method, queryParams, postBody, headerParams, formParams, fileParams,
+                pathParams, contentType);
+            RestClient.UserAgent = Configuration.UserAgent;
+            InterceptRequest(request);
+            var response = await RestClient.Execute{{^netStandard}}TaskAsync{{/netStandard}}(request, cancellationToken);
+            InterceptResponse(request, response);
+            return (Object)response;
+        }{{/supportsAsync}}
+
+        /// <summary>
+        /// Escape string (url-encoded).
+        /// </summary>
+        /// <param name="str">String to be escaped.</param>
+        /// <returns>Escaped string.</returns>
+        public string EscapeString(string str)
+        {
+            return UrlEncode(str);
+        }
+
+        /// <summary>
+        /// Create FileParameter based on Stream.
+        /// </summary>
+        /// <param name="name">Parameter name.</param>
+        /// <param name="stream">Input stream.</param>
+        /// <returns>FileParameter.</returns>
+        public FileParameter ParameterToFile(string name, Stream stream)
+        {
+            if (stream is FileStream)
+                return FileParameter.Create(name, ReadAsBytes(stream), Path.GetFileName(((FileStream)stream).Name));
+            else
+                return FileParameter.Create(name, ReadAsBytes(stream), "no_file_name_provided");
+        }
+
+        /// <summary>
+        /// If parameter is DateTime, output in a formatted string (default ISO 8601), customizable with Configuration.DateTime.
+        /// If parameter is a list, join the list with ",".
+        /// Otherwise just return the string.
+        /// </summary>
+        /// <param name="obj">The parameter (header, path, query, form).</param>
+        /// <returns>Formatted string.</returns>
+        public string ParameterToString(object obj)
+        {
+            if (obj is DateTime)
+                // Return a formatted date string - Can be customized with Configuration.DateTimeFormat
+                // Defaults to an ISO 8601, using the known as a Round-trip date/time pattern ("o")
+                // https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#Anchor_8
+                // For example: 2009-06-15T13:45:30.0000000
+                return ((DateTime)obj).ToString (Configuration.DateTimeFormat);
+            else if (obj is DateTimeOffset)
+                // Return a formatted date string - Can be customized with Configuration.DateTimeFormat
+                // Defaults to an ISO 8601, using the known as a Round-trip date/time pattern ("o")
+                // https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#Anchor_8
+                // For example: 2009-06-15T13:45:30.0000000
+                return ((DateTimeOffset)obj).ToString (Configuration.DateTimeFormat);
+            else if (obj is bool)
+                return (bool)obj ? "true" : "false";
+            else if (obj is IList)
+            {
+                var flattenedString = new StringBuilder();
+                foreach (var param in (IList)obj)
+                {
+                    if (flattenedString.Length > 0)
+                        flattenedString.Append(",");
+                    flattenedString.Append(param);
+                }
+                return flattenedString.ToString();
+            }
+            else
+                return Convert.ToString (obj);
+        }
+
+        /// <summary>
+        /// Deserialize the JSON string into a proper object.
+        /// </summary>
+        /// <param name="response">The HTTP response.</param>
+        /// <param name="type">Object type.</param>
+        /// <returns>Object representation of the JSON string.</returns>
+        public object Deserialize(IRestResponse response, Type type)
+        {
+            {{^netStandard}}IList<Parameter>{{/netStandard}}{{#netStandard}}IHttpHeaders{{/netStandard}} headers = response.Headers;
+            if (type == typeof(byte[])) // return byte array
+            {
+                return response.RawBytes;
+            }
+
+            // TODO: ? if (type.IsAssignableFrom(typeof(Stream)))
+            if (type == typeof(Stream))
+            {
+                if (headers != null)
+                {
+                    var filePath = String.IsNullOrEmpty(Configuration.TempFolderPath)
+                        ? Path.GetTempPath()
+                        : Configuration.TempFolderPath;
+                    var regex = new Regex(@"Content-Disposition=.*filename=['""]?([^'""\s]+)['""]?$");
+                    foreach (var header in headers)
+                    {
+                        var match = regex.Match(header.ToString());
+                        if (match.Success)
+                        {
+                            string fileName = filePath + SanitizeFilename(match.Groups[1].Value.Replace("\"", "").Replace("'", ""));
+                            File.WriteAllBytes(fileName, response.RawBytes);
+                            return new FileStream(fileName, FileMode.Open);
+                        }
+                    }
+                }
+                var stream = new MemoryStream(response.RawBytes);
+                return stream;
+            }
+
+            if (type.Name.StartsWith("System.Nullable`1[[System.DateTime")) // return a datetime object
+            {
+                return DateTime.Parse(response.Content,  null, System.Globalization.DateTimeStyles.RoundtripKind);
+            }
+
+            if (type == typeof(String) || type.Name.StartsWith("System.Nullable")) // return primitive type
+            {
+                return ConvertType(response.Content, type);
+            }
+
+            // at this point, it must be a model (json)
+            try
+            {
+                return JsonConvert.DeserializeObject(response.Content, type, serializerSettings);
+            }
+            catch (Exception e)
+            {
+                throw new ApiException(500, e.Message);
+            }
+        }
+
+        /// <summary>
+        /// Serialize an input (model) into JSON string
+        /// </summary>
+        /// <param name="obj">Object.</param>
+        /// <returns>JSON string.</returns>
+        public String Serialize(object obj)
+        {
+            try
+            {
+                return obj != null ? JsonConvert.SerializeObject(obj) : null;
+            }
+            catch (Exception e)
+            {
+                throw new ApiException(500, e.Message);
+            }
+        }
+
+        /// <summary>
+        ///Check if the given MIME is a JSON MIME.
+        ///JSON MIME examples:
+        ///    application/json
+        ///    application/json; charset=UTF8
+        ///    APPLICATION/JSON
+        ///    application/vnd.company+json
+        /// </summary>
+        /// <param name="mime">MIME</param>
+        /// <returns>Returns True if MIME type is json.</returns>
+        public bool IsJsonMime(String mime)
+        {
+            var jsonRegex = new Regex("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+            return mime != null && (jsonRegex.IsMatch(mime) || mime.Equals("application/json-patch+json"));
+        }
+
+        /// <summary>
+        /// Select the Content-Type header's value from the given content-type array:
+        /// if JSON type exists in the given array, use it;
+        /// otherwise use the first one defined in 'consumes'
+        /// </summary>
+        /// <param name="contentTypes">The Content-Type array to select from.</param>
+        /// <returns>The Content-Type header to use.</returns>
+        public String SelectHeaderContentType(String[] contentTypes)
+        {
+            if (contentTypes.Length == 0)
+                return "application/json";
+
+            foreach (var contentType in contentTypes)
+            {
+                if (IsJsonMime(contentType.ToLower()))
+                    return contentType;
+            }
+
+            return contentTypes[0]; // use the first content type specified in 'consumes'
+        }
+
+        /// <summary>
+        /// Select the Accept header's value from the given accepts array:
+        /// if JSON exists in the given array, use it;
+        /// otherwise use all of them (joining into a string)
+        /// </summary>
+        /// <param name="accepts">The accepts array to select from.</param>
+        /// <returns>The Accept header to use.</returns>
+        public String SelectHeaderAccept(String[] accepts)
+        {
+            if (accepts.Length == 0)
+                return null;
+
+            if (accepts.Contains("application/json", StringComparer.OrdinalIgnoreCase))
+                return "application/json";
+
+            return String.Join(",", accepts);
+        }
+
+        /// <summary>
+        /// Encode string in base64 format.
+        /// </summary>
+        /// <param name="text">String to be encoded.</param>
+        /// <returns>Encoded string.</returns>
+        public static string Base64Encode(string text)
+        {
+            return System.Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(text));
+        }
+
+        /// <summary>
+        /// Dynamically cast the object into target type.
+        /// </summary>
+        /// <param name="fromObject">Object to be casted</param>
+        /// <param name="toObject">Target type</param>
+        /// <returns>Casted object</returns>
+        {{#supportsAsync}}
+        public static dynamic ConvertType(dynamic fromObject, Type toObject)
+        {{/supportsAsync}}
+        {{^supportsAsync}}
+        public static object ConvertType<T>(T fromObject, Type toObject) where T : class
+        {{/supportsAsync}}
+        {
+            return Convert.ChangeType(fromObject, toObject);
+        }
+
+        /// <summary>
+        /// Convert stream to byte array
+        /// </summary>
+        /// <param name="inputStream">Input stream to be converted</param>
+        /// <returns>Byte array</returns>
+        public static byte[] ReadAsBytes(Stream inputStream)
+        {
+            byte[] buf = new byte[16*1024];
+            using (MemoryStream ms = new MemoryStream())
+            {
+                int count;
+                while ((count = inputStream.Read(buf, 0, buf.Length)) > 0)
+                {
+                    ms.Write(buf, 0, count);
+                }
+                return ms.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// URL encode a string
+        /// Credit/Ref: https://github.com/restsharp/RestSharp/blob/master/RestSharp/Extensions/StringExtensions.cs#L50
+        /// </summary>
+        /// <param name="input">String to be URL encoded</param>
+        /// <returns>Byte array</returns>
+        public static string UrlEncode(string input)
+        {
+            const int maxLength = 32766;
+
+            if (input == null)
+            {
+                throw new ArgumentNullException("input");
+            }
+
+            if (input.Length <= maxLength)
+            {
+                return Uri.EscapeDataString(input);
+            }
+
+            StringBuilder sb = new StringBuilder(input.Length * 2);
+            int index = 0;
+
+            while (index < input.Length)
+            {
+                int length = Math.Min(input.Length - index, maxLength);
+                string subString = input.Substring(index, length);
+
+                sb.Append(Uri.EscapeDataString(subString));
+                index += subString.Length;
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Sanitize filename by removing the path
+        /// </summary>
+        /// <param name="filename">Filename</param>
+        /// <returns>Filename</returns>
+        public static string SanitizeFilename(string filename)
+        {
+            Match match = Regex.Match(filename, @".*[/\\](.*)$");
+
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+            else
+            {
+                return filename;
+            }
+        }
+        {{^netStandard}}
+        {{#supportsUWP}}
+        /// <summary>
+        /// Convert stream to byte array
+        /// </summary>
+        /// <param name="stream">IO stream</param>
+        /// <returns>Byte array</returns>
+        public static byte[] ToByteArray(Stream stream)
+        {
+            stream.Position = 0;
+            byte[] buffer = new byte[stream.Length];
+            for (int totalBytesCopied = 0; totalBytesCopied < stream.Length;)
+                totalBytesCopied += stream.Read(buffer, totalBytesCopied, Convert.ToInt32(stream.Length) - totalBytesCopied);
+            return buffer;
+        }
+        {{/supportsUWP}}
+        {{/netStandard}}
+
+        /// <summary>
+        /// Convert params to key/value pairs.
+        /// Use collectionFormat to properly format lists and collections.
+        /// </summary>
+        /// <param name="collectionFormat">Collection format.</param>
+        /// <param name="name">Key name.</param>
+        /// <param name="value">Value object.</param>
+        /// <returns>A list of KeyValuePairs</returns>
+        public IEnumerable<KeyValuePair<string, string>> ParameterToKeyValuePairs(string collectionFormat, string name, object value)
+        {
+            var parameters = new List<KeyValuePair<string, string>>();
+
+            if (IsCollection(value) && collectionFormat == "multi")
+            {
+                var valueCollection = value as IEnumerable;
+                parameters.AddRange(from object item in valueCollection select new KeyValuePair<string, string>(name, ParameterToString(item)));
+            }
+            else
+            {
+                parameters.Add(new KeyValuePair<string, string>(name, ParameterToString(value)));
+            }
+
+            return parameters;
+        }
+
+        /// <summary>
+        /// Check if generic object is a collection.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns>True if object is a collection type</returns>
+        private static bool IsCollection(object value)
+        {
+            return value is IList || value is ICollection;
+        }
+    }
+}

--- a/generate/default_templates/OAuthAuthenticator.mustache
+++ b/generate/default_templates/OAuthAuthenticator.mustache
@@ -1,0 +1,87 @@
+{{>partial_header}}
+
+using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using RestSharp;
+using RestSharp.Authenticators;
+
+namespace {{packageName}}.Client.Auth
+{
+    /// <summary>
+    /// An authenticator for OAuth2 authentication flows
+    /// </summary>
+    public class OAuthAuthenticator : AuthenticatorBase
+    {
+        readonly string _tokenUrl;
+        readonly string _clientId;
+        readonly string _clientSecret;
+        readonly string _grantType;
+        readonly JsonSerializerSettings _serializerSettings;
+        readonly IReadableConfiguration _configuration;
+
+        /// <summary>
+        /// Initialize the OAuth2 Authenticator
+        /// </summary>
+        public OAuthAuthenticator(
+            string tokenUrl,
+            string clientId,
+            string clientSecret,
+            OAuthFlow? flow,
+            JsonSerializerSettings serializerSettings,
+            IReadableConfiguration configuration) : base("")
+        {
+            _tokenUrl = tokenUrl;
+            _clientId = clientId;
+            _clientSecret = clientSecret;
+            _serializerSettings = serializerSettings;
+            _configuration = configuration;
+
+            switch (flow)
+            {
+                /*case OAuthFlow.ACCESS_CODE:
+                    _grantType = "authorization_code";
+                    break;
+                case OAuthFlow.IMPLICIT:
+                    _grantType = "implicit";
+                    break;
+                case OAuthFlow.PASSWORD:
+                    _grantType = "password";
+                    break;*/
+                case OAuthFlow.APPLICATION:
+                    _grantType = "client_credentials";
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Creates an authentication parameter from an access token.
+        /// </summary>
+        /// <param name="accessToken">Access token to create a parameter from.</param>
+        /// <returns>An authentication parameter.</returns>
+        protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
+        {
+            var token = string.IsNullOrEmpty(Token) ? await GetToken().ConfigureAwait(false) : Token;
+            return new HeaderParameter(KnownHeaders.Authorization, token);
+        }
+
+        /// <summary>
+        /// Gets the token from the OAuth2 server.
+        /// </summary>
+        /// <returns>An authentication token.</returns>
+        async Task<string> GetToken()
+        {
+            var client = new RestClient(_tokenUrl)
+                .UseSerializer(() => new CustomJsonCodec(_serializerSettings, _configuration));
+
+            var request = new RestRequest()
+                .AddParameter("grant_type", _grantType)
+                .AddParameter("client_id", _clientId)
+                .AddParameter("client_secret", _clientSecret);
+            var response = await client.PostAsync<TokenResponse>(request).ConfigureAwait(false);
+            return $"{response.TokenType} {response.AccessToken}";
+        }
+    }
+}

--- a/generate/templates/ApiClient.mustache
+++ b/generate/templates/ApiClient.mustache
@@ -42,7 +42,7 @@ namespace {{packageName}}.Client
     internal class CustomJsonCodec : IRestSerializer, ISerializer, IDeserializer
     {
         private readonly IReadableConfiguration _configuration;
-        private static readonly string _contentType = "application/json";
+        private static readonly ContentType _contentType = ContentType.Json;
         private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
         {
             // OpenAPI generated types generally hide default constructors.
@@ -156,17 +156,18 @@ namespace {{packageName}}.Client
         public ISerializer Serializer => this;
         public IDeserializer Deserializer => this;
 
-        public string[] AcceptedContentTypes => RestSharp.Serializers.ContentType.JsonAccept;
+        public string[] AcceptedContentTypes => ContentType.JsonAccept;
 
         public SupportsContentType SupportsContentType => contentType =>
-            contentType.EndsWith("json", StringComparison.InvariantCultureIgnoreCase) ||
-            contentType.EndsWith("javascript", StringComparison.InvariantCultureIgnoreCase);
+            contentType.Value.EndsWith("json", StringComparison.InvariantCultureIgnoreCase) ||
+            contentType.Value.EndsWith("javascript", StringComparison.InvariantCultureIgnoreCase);
 
-        public string ContentType
+        public ContentType ContentType
         {
             get { return _contentType; }
             set { throw new InvalidOperationException("Not allowed to set content type."); }
         }
+
 
         public DataFormat DataFormat => DataFormat.Json;
     }
@@ -331,7 +332,7 @@ namespace {{packageName}}.Client
             {
                 foreach (var pathParam in options.PathParameters)
                 {
-                    request.AddParameter(pathParam.Key, pathParam.Value, ParameterType.UrlSegment);
+                    request.AddParameter(pathParam.Key, pathParam.Value, ParameterType.UrlSegment, false);
                 }
             }
 
@@ -509,23 +510,24 @@ namespace {{packageName}}.Client
                 ConfigureMessageHandler = ConfigureMessageHandler
             };
 
-            RestClient client = new RestClient(clientOptions)
-                .UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration));
-
             {{#hasOAuthMethods}}
             if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
                 !string.IsNullOrEmpty(configuration.OAuthClientId) &&
                 !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
                 configuration.OAuthFlow != null)
             {
-                client = client.UseAuthenticator(new OAuthAuthenticator(
+                clientOptions.Authenticator= new OAuthAuthenticator(
                     configuration.OAuthTokenUrl,
                     configuration.OAuthClientId,
                     configuration.OAuthClientSecret,
                     configuration.OAuthFlow,
                     SerializerSettings,
-                    configuration));
+                    configuration);
             }
+
+            RestClient client = new RestClient(clientOptions,
+                configureSerialization: s =>
+                    s.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration)));
 
             {{/hasOAuthMethods}}
             InterceptRequest(req);
@@ -535,9 +537,8 @@ namespace {{packageName}}.Client
             {
                 var policy = RetryConfiguration.RetryPolicy;
                 var policyResult = policy.ExecuteAndCapture(() => client.Execute(req));
-                response = (policyResult.Outcome == OutcomeType.Successful) ? client.Deserialize<T>(policyResult.Result) : new RestResponse<T>
+                response = (policyResult.Outcome == OutcomeType.Successful) ? client.Deserialize<T>(policyResult.Result) : new RestResponse<T>(req)
                 {
-                    Request = req,
                     ErrorException = policyResult.FinalException
                 };
             }
@@ -622,23 +623,24 @@ namespace {{packageName}}.Client
                 ConfigureMessageHandler = ConfigureMessageHandler
             };
 
-            RestClient client = new RestClient(clientOptions)
-                .UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration));
-
             {{#hasOAuthMethods}}
             if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
                 !string.IsNullOrEmpty(configuration.OAuthClientId) &&
                 !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
                 configuration.OAuthFlow != null)
             {
-                client = client.UseAuthenticator(new OAuthAuthenticator(
+                clientOptions.Authenticator = new OAuthAuthenticator(
                     configuration.OAuthTokenUrl,
                     configuration.OAuthClientId,
                     configuration.OAuthClientSecret,
                     configuration.OAuthFlow,
                     SerializerSettings,
-                    configuration));
+                    configuration);
             }
+
+            RestClient client = new RestClient(clientOptions,
+                configureSerialization: s =>
+                    s.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration)));
 
             {{/hasOAuthMethods}}
             InterceptRequest(req);
@@ -649,9 +651,8 @@ namespace {{packageName}}.Client
             {
                 var policy = RetryConfiguration.AsyncRetryPolicy;
                 var policyResult = await policy.ExecuteAndCaptureAsync((ct) => client.ExecuteAsync(req, ct), cancellationToken).ConfigureAwait(false);
-                response = (policyResult.Outcome == OutcomeType.Successful) ? client.Deserialize<T>(policyResult.Result) : new RestResponse<T>
+                response = (policyResult.Outcome == OutcomeType.Successful) ? client.Deserialize<T>(policyResult.Result) : new RestResponse<T>(req)
                 {
-                    Request = req,
                     ErrorException = policyResult.FinalException
                 };
             }

--- a/generate/templates/ApiClient.mustache
+++ b/generate/templates/ApiClient.mustache
@@ -507,8 +507,7 @@ namespace {{packageName}}.Client
                 MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
-                ConfigureMessageHandler = ConfigureMessageHandler,
-                Encode = s => System.Uri.EscapeDataString(s)
+                ConfigureMessageHandler = ConfigureMessageHandler
             };
 
             {{#hasOAuthMethods}}
@@ -621,8 +620,7 @@ namespace {{packageName}}.Client
                 MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
-                ConfigureMessageHandler = ConfigureMessageHandler,
-                Encode = s => System.Uri.EscapeDataString(s)
+                ConfigureMessageHandler = ConfigureMessageHandler
             };
 
             {{#hasOAuthMethods}}

--- a/generate/templates/ApiClient.mustache
+++ b/generate/templates/ApiClient.mustache
@@ -332,7 +332,7 @@ namespace {{packageName}}.Client
             {
                 foreach (var pathParam in options.PathParameters)
                 {
-                    request.AddParameter(pathParam.Key, pathParam.Value, ParameterType.UrlSegment, false);
+                    request.AddParameter(pathParam.Key, pathParam.Value, ParameterType.UrlSegment);
                 }
             }
 
@@ -507,7 +507,8 @@ namespace {{packageName}}.Client
                 MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
-                ConfigureMessageHandler = ConfigureMessageHandler
+                ConfigureMessageHandler = ConfigureMessageHandler,
+                Encode = s => System.Uri.EscapeDataString(s)
             };
 
             {{#hasOAuthMethods}}
@@ -620,7 +621,8 @@ namespace {{packageName}}.Client
                 MaxTimeout = configuration.Timeout,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
-                ConfigureMessageHandler = ConfigureMessageHandler
+                ConfigureMessageHandler = ConfigureMessageHandler,
+                Encode = s => System.Uri.EscapeDataString(s)
             };
 
             {{#hasOAuthMethods}}

--- a/generate/templates/auth/OAuthAuthenticator.mustache
+++ b/generate/templates/auth/OAuthAuthenticator.mustache
@@ -1,0 +1,87 @@
+{{>partial_header}}
+
+using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using RestSharp;
+using RestSharp.Authenticators;
+
+namespace {{packageName}}.Client.Auth
+{
+    /// <summary>
+    /// An authenticator for OAuth2 authentication flows
+    /// </summary>
+    public class OAuthAuthenticator : AuthenticatorBase
+    {
+        readonly string _tokenUrl;
+        readonly string _clientId;
+        readonly string _clientSecret;
+        readonly string _grantType;
+        readonly JsonSerializerSettings _serializerSettings;
+        readonly IReadableConfiguration _configuration;
+
+        /// <summary>
+        /// Initialize the OAuth2 Authenticator
+        /// </summary>
+        public OAuthAuthenticator(
+            string tokenUrl,
+            string clientId,
+            string clientSecret,
+            OAuthFlow? flow,
+            JsonSerializerSettings serializerSettings,
+            IReadableConfiguration configuration) : base("")
+        {
+            _tokenUrl = tokenUrl;
+            _clientId = clientId;
+            _clientSecret = clientSecret;
+            _serializerSettings = serializerSettings;
+            _configuration = configuration;
+
+            switch (flow)
+            {
+                /*case OAuthFlow.ACCESS_CODE:
+                    _grantType = "authorization_code";
+                    break;
+                case OAuthFlow.IMPLICIT:
+                    _grantType = "implicit";
+                    break;
+                case OAuthFlow.PASSWORD:
+                    _grantType = "password";
+                    break;*/
+                case OAuthFlow.APPLICATION:
+                    _grantType = "client_credentials";
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Creates an authentication parameter from an access token.
+        /// </summary>
+        /// <param name="accessToken">Access token to create a parameter from.</param>
+        /// <returns>An authentication parameter.</returns>
+        protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
+        {
+            var token = string.IsNullOrEmpty(Token) ? await GetToken().ConfigureAwait(false) : Token;
+            return new HeaderParameter(KnownHeaders.Authorization, token);
+        }
+
+        /// <summary>
+        /// Gets the token from the OAuth2 server.
+        /// </summary>
+        /// <returns>An authentication token.</returns>
+        async Task<string> GetToken()
+        {
+            var client = new RestClient(_tokenUrl,
+                configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(_serializerSettings, _configuration)));
+
+            var request = new RestRequest()
+                .AddParameter("grant_type", _grantType)
+                .AddParameter("client_id", _clientId)
+                .AddParameter("client_secret", _clientSecret);
+            var response = await client.PostAsync<TokenResponse>(request).ConfigureAwait(false);
+            return $"{response.TokenType} {response.AccessToken}";
+        }
+    }
+}

--- a/generate/templates/netcore_project.mustache
+++ b/generate/templates/netcore_project.mustache
@@ -33,7 +33,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     {{/useGenericHost}}
       {{#useRestSharp}}
-    <PackageReference Include="RestSharp" Version="108.0.3" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
       {{/useRestSharp}}
       {{#useGenericHost}}
     <PackageReference Include="Microsoft.Extensions.Http" Version="{{^netStandard}}7.0.0{{/netStandard}}{{#netStandard}}5.0.0{{/netStandard}}" />

--- a/generate/templates/other/ApiFactory.mustache
+++ b/generate/templates/other/ApiFactory.mustache
@@ -84,7 +84,8 @@ namespace {{packageName}}.Extensions
         public ApiFactory(Client.Configuration configuration)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-
+            configuration.MergeWithGlobalConfiguration();
+            
             _apis = Init(configuration);
         }
 

--- a/generate/templates/other/DateTimeOrCutLabel.mustache
+++ b/generate/templates/other/DateTimeOrCutLabel.mustache
@@ -21,6 +21,10 @@ namespace {{packageName}}
 
         internal DateTimeOrCutLabel(string parameter)
         {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
             Parameter = parameter;
         }
 

--- a/generate/templates/other/TokenProviderConfiguration.mustache
+++ b/generate/templates/other/TokenProviderConfiguration.mustache
@@ -30,11 +30,17 @@ namespace {{packageName}}.Extensions
             get => _tokenProvider.GetAuthenticationTokenAsync().Result;
             set => throw new InvalidOperationException("AccessToken is not assignable");
         }
+    }
 
+    /// <summary>
+    /// Configuation methods extensions.
+    /// </summary>
+    public static class ConfigurationExtensionMethods
+    {
         /// <summary>
         /// Merge configuration with the global config.
         /// </summary>
-        public void MergeWithGlobalConfiguration()
+        public static void MergeWithGlobalConfiguration(this Client.Configuration config)
         {
             var global = GlobalConfiguration.Instance;
 
@@ -42,33 +48,33 @@ namespace {{packageName}}.Extensions
             Dictionary<string, string> apiKeyPrefix = global.ApiKeyPrefix.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             Dictionary<string, string> defaultHeaders = global.DefaultHeaders.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-            foreach (var kvp in ApiKey) apiKey[kvp.Key] = kvp.Value;
-            foreach (var kvp in ApiKeyPrefix) apiKeyPrefix[kvp.Key] = kvp.Value;
-            foreach (var kvp in DefaultHeaders) defaultHeaders[kvp.Key] = kvp.Value;
+            foreach (var kvp in config.ApiKey) apiKey[kvp.Key] = kvp.Value;
+            foreach (var kvp in config.ApiKeyPrefix) apiKeyPrefix[kvp.Key] = kvp.Value;
+            foreach (var kvp in config.DefaultHeaders) defaultHeaders[kvp.Key] = kvp.Value;
 
-            ApiKey = apiKey;
-            ApiKeyPrefix = apiKeyPrefix;
-            DefaultHeaders = defaultHeaders;
-            BasePath = BasePath ?? global.BasePath;
-            Timeout = Timeout;
-            Proxy = Proxy ?? global.Proxy;
-            UserAgent = UserAgent ?? global.UserAgent;
-            Username = Username ?? global.Username;
-            Password = Password ?? global.Password;
+            config.ApiKey = apiKey;
+            config.ApiKeyPrefix = apiKeyPrefix;
+            config.DefaultHeaders = defaultHeaders;
+            config.BasePath = config.BasePath ?? global.BasePath;
+            config.Timeout = config.Timeout;
+            config.Proxy = config.Proxy ?? global.Proxy;
+            config.UserAgent = config.UserAgent ?? global.UserAgent;
+            config.Username = config.Username ?? global.Username;
+            config.Password = config.Password ?? global.Password;
             {{#useRestSharp}}
             {{#hasOAuthMethods}}
-            OAuthTokenUrl = OAuthTokenUrl ?? global.OAuthTokenUrl;
-            OAuthClientId = OAuthClientId ?? global.OAuthClientId;
-            OAuthClientSecret = OAuthClientSecret ?? global.OAuthClientSecret;
-            OAuthFlow = OAuthFlow ?? global.OAuthFlow;
+            config.OAuthTokenUrl = config.OAuthTokenUrl ?? global.OAuthTokenUrl;
+            config.OAuthClientId = config.OAuthClientId ?? global.OAuthClientId;
+            config.OAuthClientSecret = config.OAuthClientSecret ?? global.OAuthClientSecret;
+            config.OAuthFlow = config.OAuthFlow ?? global.OAuthFlow;
             {{/hasOAuthMethods}}
             {{/useRestSharp}}
             {{#hasHttpSignatureMethods}}
-            HttpSigningConfiguration = HttpSigningConfiguration ?? global.HttpSigningConfiguration;
+            config.HttpSigningConfiguration = config.HttpSigningConfiguration ?? global.HttpSigningConfiguration;
             {{/hasHttpSignatureMethods}}
-            TempFolderPath = TempFolderPath ?? global.TempFolderPath;
-            DateTimeFormat = DateTimeFormat ?? global.DateTimeFormat;
-            ClientCertificates = ClientCertificates ?? global.ClientCertificates;
+            config.TempFolderPath = config.TempFolderPath ?? global.TempFolderPath;
+            config.DateTimeFormat = config.DateTimeFormat ?? global.DateTimeFormat;
+            config.ClientCertificates = config.ClientCertificates ?? global.ClientCertificates;
         }
     }
 }


### PR DESCRIPTION
Updates RestSharp client to allow for mocking of RestClient via IRestClient.

Discovered that under certain conditions, the global config, which contains the headers for version and language, was not being merged with the user supplied config.  Small fix for this as well.

Also adds a fix for encoding of url segment params.