### PR TITLE
fix: Ensures baseurl can be loaded from config as {app}Url

### DIFF
--- a/generate/templates/netcore_project.additions.mustache
+++ b/generate/templates/netcore_project.additions.mustache
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
   </ItemGroup>

--- a/generate/templates/other/ApiConfiguration.mustache
+++ b/generate/templates/other/ApiConfiguration.mustache
@@ -38,7 +38,7 @@ namespace {{packageName}}.Extensions
         /// <summary>
         /// {{#lambda.titlecase}}{{#lambda.lowercase}}{{application}}{{/lambda.lowercase}}{{/lambda.titlecase}} Api Url
         /// </summary>
-        [ConfigurationKeyName("{{#lambda.lowercase}}{{application}}{{/lambda.lowercase}}")]
+        [ConfigurationKeyName("{{#lambda.lowercase}}{{application}}{{/lambda.lowercase}}Url")]
         public string BaseUrl { get; set; }
 
         /// <summary>

--- a/generate/templates/other/ApiConfiguration.mustache
+++ b/generate/templates/other/ApiConfiguration.mustache
@@ -1,6 +1,7 @@
 {{>partial_header}}
 
 using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
 
 namespace {{packageName}}.Extensions
 {
@@ -37,6 +38,7 @@ namespace {{packageName}}.Extensions
         /// <summary>
         /// {{#lambda.titlecase}}{{#lambda.lowercase}}{{application}}{{/lambda.lowercase}}{{/lambda.titlecase}} Api Url
         /// </summary>
+        [ConfigurationKeyName("{{#lambda.lowercase}}{{application}}{{/lambda.lowercase}}")]
         public string BaseUrl { get; set; }
 
         /// <summary>


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

We discovered that the secrets.json file setting was not loading the baseurl and was actually reporting it as the wrong config option as well.  This fixes that by adding an annotation to BaseUrl that names the config item correctly.