### PR TITLE
Returns a default DateTimeOrCutLabel for a null string

### DIFF
--- a/generate/templates/other/DateTimeOrCutLabel.mustache
+++ b/generate/templates/other/DateTimeOrCutLabel.mustache
@@ -63,6 +63,10 @@ namespace {{packageName}}
         /// </summary>
         public static implicit operator DateTimeOrCutLabel(string cutLabel)
         {
+            if (cutLabel == null)
+            {
+                return default(DateTimeOrCutLabel);
+            }
             return new DateTimeOrCutLabel(cutLabel);
         }
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass

# Description of the PR

implicitly converting a null string results in an exception. This should result in a NULL DateTimeOrCutLabel.
