### PR TITLE
Feature/ctech 3410 dotnet v 2 sdk requires app name to be set to make requests

### DIFF
--- a/generate/templates/Solution.mustache
+++ b/generate/templates/Solution.mustache
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio {{^netStandard}}2012{{/netStandard}}{{#netStandard}}14{{/netStandard}}
 VisualStudioVersion = {{^netStandard}}12.0.0.0{{/netStandard}}{{#netStandard}}14.0.25420.1{{/netStandard}}
 MinimumVisualStudioVersion = {{^netStandard}}10.0.0.1{{/netStandard}}{{#netStandard}}10.0.40219.1{{/netStandard}}
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{packageName}}", "{{packageName}}\{{packageName}}.csproj", "{{packageGuid}}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{packageName}}", "{{packageName}}\{{packageName}}.csproj", "{{=<% %>=}}{<% packageGuid %>}<%={{ }}=%>"
 EndProject
 {{^excludeTests}}Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{testPackageName}}", "{{testPackageName}}\{{testPackageName}}.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,14 +12,18 @@ EndProject
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{{packageGuid}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{{packageGuid}}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{{packageGuid}}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{{packageGuid}}.Release|Any CPU.Build.0 = Release|Any CPU
+	{{=<% %>=}}
+		{<% packageGuid %>}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{<% packageGuid %>}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{<% packageGuid %>}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{<% packageGuid %>}.Release|Any CPU.Build.0 = Release|Any CPU
+	<%={{ }}=%>
+	{{^excludeTests}}
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.Build.0 = Release|Any CPU
+	{{/excludeTests}}
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/generate/templates/netcore_project.mustache
+++ b/generate/templates/netcore_project.mustache
@@ -2,7 +2,7 @@
 
   <PropertyGroup>{{#useGenericHost}}
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo> <!-- setting GenerateAssemblyInfo to false causes this bug https://github.com/dotnet/project-system/issues/3934 -->{{/useGenericHost}}{{^useGenericHost}}
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo><!-- setting GenerateAssemblyInfo to false causes this bug https://github.com/dotnet/project-system/issues/3934 -->{{/useGenericHost}}
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo><!-- setting GenerateAssemblyInfo to false causes this bug https://github.com/dotnet/project-system/issues/3934 -->{{/useGenericHost}}
     <TargetFramework{{#multiTarget}}s{{/multiTarget}}>{{targetFramework}}</TargetFramework{{#multiTarget}}s{{/multiTarget}}>
     <AssemblyName>{{packageName}}</AssemblyName>
     <PackageId>{{projectName}}</PackageId>
@@ -48,6 +48,9 @@
     {{#validatable}}
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     {{/validatable}}
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Finbourne.Sdk.Extensions.Tests" />
   </ItemGroup>
 
 {{>netcore_project.additions}}</Project>

--- a/generate/templates/other/ApiFactory.mustache
+++ b/generate/templates/other/ApiFactory.mustache
@@ -70,8 +70,10 @@ namespace {{packageName}}.Extensions
             {
                 BasePath = apiConfiguration.BaseUrl,
             };
-            
-            configuration.DefaultHeaders.Add("X-LUSID-Application", apiConfiguration.ApplicationName);
+            if(!String.IsNullOrWhiteSpace(apiConfiguration.ApplicationName))
+            {
+                configuration.DefaultHeaders.Add("X-LUSID-Application", apiConfiguration.ApplicationName);
+            }
             configuration.MergeWithGlobalConfiguration();
             
             _apis = Init(configuration);

--- a/generate/templates/other/AssemblyInfo.mustache
+++ b/generate/templates/other/AssemblyInfo.mustache
@@ -1,3 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Finbourne.Sdk.Extensions.Tests")]

--- a/tests/Tests/Unit/ApiConfigurationBuilderTest.cs
+++ b/tests/Tests/Unit/ApiConfigurationBuilderTest.cs
@@ -84,7 +84,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
                 {"password", "<password>"},
                 {"clientId", "<clientId>"},
                 {"clientSecret", "<clientSecret>"},
-                {"baseUrl", string.Format("<{0}Url>", "test")},
+                {"lusidUrl", string.Format("<{0}Url>", "test")},
             });
             var apiConfiguration = ApiConfigurationBuilder.Build(_secretsFile);
             Assert.That(apiConfiguration.TokenUrl, Is.EqualTo("<tokenUrl>"));
@@ -105,7 +105,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
                 {"password", "<password>"},
                 // {"clientId", "<clientId>"},
                 {"clientSecret", "<clientSecret>"},
-                {"baseUrl", string.Format("<{0}Url>", "test")},
+                {"lusidUrl", string.Format("<{0}Url>", "test")},
             });
             var exception = Assert.Throws<MissingConfigException>(() => ApiConfigurationBuilder.Build(_secretsFile));
             Assert.That(exception.Message,
@@ -158,7 +158,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             var settings = new Dictionary<string, string>
             {
                 { "api:TokenUrl", "<tokenUrl>" },
-                { "api:BaseUrl", string.Format("<env.{0}Url>", "test") },
+                { "api:LusidUrl", string.Format("<env.{0}Url>", "test") },
                 { "api:ClientId", "<clientId>" },
                 { "api:ClientSecret", "<clientSecret>" },
                 { "api:Username", "<username>" },
@@ -191,7 +191,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             var settings = new Dictionary<string, string>
             {
                 { "api:TokenUrl", "<tokenUrl>" },
-                { "api:BaseUrl", string.Format("<{0}Url>", "test") },
+                { "api:LusidUrl", string.Format("<{0}Url>", "test") },
                 { "api:ClientId", "<clientId>" },
                 { "api:ClientSecret", "" },
                 { "api:Username", "<username>" },

--- a/tests/Tests/Unit/ApiFactoryBuilderTest.cs
+++ b/tests/Tests/Unit/ApiFactoryBuilderTest.cs
@@ -17,7 +17,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             {
                 ["api"] = new Dictionary<string, string>()
                 {
-                    {"baseUrl", "https://sub-domain.lusid.com/api"},
+                    {"lusidUrl", "https://sub-domain.lusid.com/api"},
                     {"tokenUrl", "https://sub-domain.okta.com/oauth2/abcd123/v1/token"},
                     {"clientId", "<clientId>"},
                     {"clientSecret", "<clientSecret>"},

--- a/tests/Tests/Unit/ApiFactoryTest.cs
+++ b/tests/Tests/Unit/ApiFactoryTest.cs
@@ -1,3 +1,4 @@
+using Lusid.Sdk.Api;
 using NUnit.Framework;
 using System;
 
@@ -31,6 +32,33 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             Assert.That(
                 () => new ApiFactory(apiConfig),
                 Throws.InstanceOf<UriFormatException>().With.Message.EqualTo("Invalid Uri: xyz"));
+        }
+
+        [Test]
+        public void NullAppName_NoLusidApplicationHeaderInApiConfig()
+        {
+            var apiConfig = new ApiConfiguration()
+            {
+                PersonalAccessToken = "test token",
+                BaseUrl = "https://example.lusid.com/api"
+            };
+            var apiFactory = new ApiFactory(apiConfig);
+            Assert.That(apiFactory.Api<ApplicationMetadataApi>().Configuration.DefaultHeaders, Does.Not.ContainKey("X-LUSID-Application"));
+        }
+
+        [Test]
+        public void AppNameProvided_LusidApplicationHeaderInApiConfig()
+        {
+            var appName = "test app name";
+            var apiConfig = new ApiConfiguration()
+            {
+                PersonalAccessToken = "test token",
+                BaseUrl = "https://example.lusid.com/api",
+                ApplicationName = appName
+            };
+            var apiFactory = new ApiFactory(apiConfig);
+            Assert.That(apiFactory.Api<ApplicationMetadataApi>().Configuration.DefaultHeaders, Does.ContainKey("X-LUSID-Application"));
+            Assert.AreEqual(appName, apiFactory.Api<ApplicationMetadataApi>().Configuration.DefaultHeaders["X-LUSID-Application"]);
         }
     }
 }

--- a/tests/Tests/Unit/ClientCredentialsFlowTokenProviderTest.cs
+++ b/tests/Tests/Unit/ClientCredentialsFlowTokenProviderTest.cs
@@ -16,7 +16,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             {
                 ["api"] = new Dictionary<string, string>()
                 {
-                    {"baseUrl", "https://sub-domain.lusid.com/api"},
+                    {"lusidUrl", "https://sub-domain.lusid.com/api"},
                     {"tokenUrl", "https://sub-domain.okta.com/oauth2/abcd123/v1/token"},
                     {"clientId", "<clientId>"},
                     {"clientSecret", "<clientSecret>"},


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Does a few things:
- Fixes tests from tests branch and adds them to this branch. To get the tests working had to generate assembly info and make internals visible to the test project. Also had to fix tests so they work with lusidUrl rather than baseUrl.

- Fixes a small bug in the generated solution file, where project GUIDs are incorrect, and the test project is referenced when it is not generated.

- Fixes another bug where if no app name is provided to the ApiFactory then requests fail due to trying to set an api header which is null.