### PR TITLE
Feature/ctech 3411 csharp sdk is not percent encoding 2 f when used in a url segment

### DIFF
--- a/generate/templates/ApiClient.mustache
+++ b/generate/templates/ApiClient.mustache
@@ -337,7 +337,10 @@ namespace {{packageName}}.Client
             {
                 foreach (var pathParam in options.PathParameters)
                 {
-                    request.AddParameter(pathParam.Key, pathParam.Value, ParameterType.UrlSegment);
+                    var segmentParameter = new UrlSegmentParameter(pathParam.Key, pathParam.Value);
+                    // %2F's are replaced in UrlSegmentParameter constructor
+                    // we don't want this
+                    request.AddParameter(segmentParameter with {Value = pathParam.Value});
                 }
             }
 

--- a/tests/Tests/Finbourne.Sdk.Extensions.Tests.csproj
+++ b/tests/Tests/Finbourne.Sdk.Extensions.Tests.csproj
@@ -11,6 +11,7 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="3.13.3 " />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />

--- a/tests/Tests/Unit/ApiClientTest.cs
+++ b/tests/Tests/Unit/ApiClientTest.cs
@@ -14,6 +14,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
     [TestFixture]
     public class ApiClientTest
     {
+
         [Test]
         public void PercentEncodedSlashSent(){
             var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
@@ -26,20 +27,15 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
                     StatusCode = HttpStatusCode.OK,
                     Content = new StringContent(req.RequestUri!.AbsolutePath ?? "oops")
                 });
-            var httpClient = new HttpClient(handler.Object);
-            var HttpClientFactoryMock = new Mock<IHttpClientFactory>();
-            HttpClientFactoryMock.Setup(httpClientFactory=>httpClientFactory.New(It.IsAny<RestClientOptions>())).Returns(httpClient);
-            var apiClient = new ApiClient("http://example.com");
+            Func<RestClientOptions, HttpMessageHandler> HttpClientFactoryMock = (options) => handler.Object;
+            var apiClient = new ApiClient("http://example.com", CreateHttpMessageHandler : HttpClientFactoryMock);
             var requestOptions = new RequestOptions(){
                 Operation = "GET",
                 PathParameters=new Dictionary<string, string>(){
                     {"arg", "prefix-%2F-suffix"}
                 }
             };
-            var config = new Configuration(){
-                HttpClientFactory = HttpClientFactoryMock.Object
-            };
-            var res = apiClient.Get<String>("/{arg}", requestOptions, configuration:config);
+            var res = apiClient.Get<String>("/{arg}", requestOptions);
 
             var req = new RestRequest(new Uri("http://example.com/{arg}"));
             

--- a/tests/Tests/Unit/ApiClientTest.cs
+++ b/tests/Tests/Unit/ApiClientTest.cs
@@ -1,0 +1,51 @@
+using System;
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using RestSharp;
+using System.Collections.Generic;
+
+namespace Finbourne.Sdk.Extensions.Tests.Unit
+{
+    [TestFixture]
+    public class ApiClientTest
+    {
+        [Test]
+        public void PercentEncodedSlashSent(){
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handler.Protected().Setup<Task<HttpResponseMessage>>(
+                    "SendAsync", 
+                    ItExpr.IsAny<HttpRequestMessage>(), 
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync((HttpRequestMessage req, CancellationToken ct) => new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(req.RequestUri!.AbsolutePath ?? "oops")
+                });
+            var httpClient = new HttpClient(handler.Object);
+            var HttpClientFactoryMock = new Mock<IHttpClientFactory>();
+            HttpClientFactoryMock.Setup(httpClientFactory=>httpClientFactory.New(It.IsAny<RestClientOptions>())).Returns(httpClient);
+            var apiClient = new ApiClient("http://example.com");
+            var requestOptions = new RequestOptions(){
+                Operation = "GET",
+                PathParameters=new Dictionary<string, string>(){
+                    {"arg", "prefix-%2F-suffix"}
+                }
+            };
+            var config = new Configuration(){
+                HttpClientFactory = HttpClientFactoryMock.Object
+            };
+            var res = apiClient.Get<String>("/{arg}", requestOptions, configuration:config);
+
+            var req = new RestRequest(new Uri("http://example.com/{arg}"));
+            
+            Assert.AreEqual(HttpStatusCode.OK, res.StatusCode);
+            Assert.AreEqual("/prefix-%252F-suffix", res.Content);
+        }
+        
+    }
+}


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `restsharp` branch

# Description of the PR

