### PR TITLE
updated ApiConfigurationBuilder to support dashes and underscores.

### DIFF
--- a/generate/templates/other/ApiConfiguration.mustache
+++ b/generate/templates/other/ApiConfiguration.mustache
@@ -43,6 +43,13 @@ namespace {{packageName}}.Extensions
         [ConfigurationKeyName("{{#lambda.lowercase}}{{application}}{{/lambda.lowercase}}Url")]
         public string BaseUrl { get; set; }
 
+
+        /// <summary>
+        /// {{#lambda.snakecase}}{{application}}{{/lambda.snakecase}} Api Url
+        /// </summary>
+        [ConfigurationKeyName("{{#lambda.snakecase}}{{application}}{{/lambda.snakecase}}Url")]
+        public string BackUpBaseUrl { get; set; }
+
         /// <summary>
         /// Client Application name
         /// </summary>
@@ -56,7 +63,7 @@ namespace {{packageName}}.Extensions
 
         internal bool MissingPersonalAccessTokenVariables =>
             string.IsNullOrWhiteSpace(PersonalAccessToken) ||
-            string.IsNullOrWhiteSpace(BaseUrl);
+            (string.IsNullOrWhiteSpace(BaseUrl) && string.IsNullOrWhiteSpace(BackUpBaseUrl));
 
         internal bool MissingSecretVariables =>
             string.IsNullOrWhiteSpace(TokenUrl) ||
@@ -64,7 +71,7 @@ namespace {{packageName}}.Extensions
             string.IsNullOrWhiteSpace(Password) ||
             string.IsNullOrWhiteSpace(ClientId) ||
             string.IsNullOrWhiteSpace(ClientSecret) ||
-            string.IsNullOrWhiteSpace(BaseUrl);
+            (string.IsNullOrWhiteSpace(BaseUrl) && string.IsNullOrWhiteSpace(BackUpBaseUrl)) ;
 
         /// <summary>
         /// Checks if any of the required configuration values are missing
@@ -117,14 +124,14 @@ namespace {{packageName}}.Extensions
                 missingConfig.Add(nameof(ClientSecret));
             }
 
-            if (string.IsNullOrWhiteSpace(BaseUrl))
+            if(string.IsNullOrWhiteSpace(BackUpBaseUrl) && string.IsNullOrWhiteSpace(BaseUrl))
             {
                 PropertyInfo propertyInfo = typeof(ApiConfiguration).GetProperty(nameof(BaseUrl));
                 var attribute = (ConfigurationKeyNameAttribute)Attribute.GetCustomAttribute(propertyInfo!, typeof(ConfigurationKeyNameAttribute));
 
                 missingConfig.Add(attribute!.Name);
             }
-
+            
             return missingConfig;
         }  
     }

--- a/generate/templates/other/ApiConfigurationBuilder.mustache
+++ b/generate/templates/other/ApiConfigurationBuilder.mustache
@@ -27,7 +27,7 @@ namespace {{packageName}}.Extensions
         private static readonly Dictionary<string, string> ConfigNamesToSecrets = new Dictionary<string, string>()
         {
             { "TokenUrl", "tokenUrl" },
-            { "BaseUrl", "{{#lambda.lowercase}}{{application}}{{/lambda.lowercase}}Url" },
+            { "BaseUrl", "{{#lambda.snakecase}}{{application}}{{/lambda.snakecase}}Url" },
             { "ClientId", "clientId" },
             { "ClientSecret", "clientSecret" },
             { "Username", "username" },
@@ -80,7 +80,10 @@ namespace {{packageName}}.Extensions
             var apiConfig = new ApiConfiguration
             {
                 TokenUrl = Environment.GetEnvironmentVariable("FBN_TOKEN_URL") ?? Environment.GetEnvironmentVariable("fbn_token_url"),
-                BaseUrl = Environment.GetEnvironmentVariable("FBN_{{#lambda.uppercase}}{{application}}{{/lambda.uppercase}}_API_URL") ?? Environment.GetEnvironmentVariable("fbn_{{#lambda.lowercase}}{{application}}{{/lambda.lowercase}}_api_url"),
+                BaseUrl = (Environment.GetEnvironmentVariable("FBN_{{#lambda.uppercase}}{{application}}{{/lambda.uppercase}}_API_URL") ?? 
+                           Environment.GetEnvironmentVariable("fbn_{{#lambda.lowercase}}{{application}}{{/lambda.lowercase}}_api_url")) ?? 
+                          (Environment.GetEnvironmentVariable("FBN_{{#lambda.uppercase}}{{#lambda.snakecase}}{{application}}{{/lambda.snakecase}}{{/lambda.uppercase}}_API_URL") ?? 
+                           Environment.GetEnvironmentVariable("fbn_{{#lambda.snakecase}}{{application}}{{/lambda.snakecase}}_api_url")),
                 ClientId = Environment.GetEnvironmentVariable("FBN_CLIENT_ID") ?? Environment.GetEnvironmentVariable("fbn_client_id"),
                 ClientSecret = Environment.GetEnvironmentVariable("FBN_CLIENT_SECRET") ?? Environment.GetEnvironmentVariable("fbn_client_secret"),
                 Username = Environment.GetEnvironmentVariable("FBN_USERNAME") ?? Environment.GetEnvironmentVariable("fbn_username"),

--- a/justfile
+++ b/justfile
@@ -8,12 +8,26 @@
 #    APPLICATION_NAME
 #    META_REQUEST_ID_HEADER_KEY
 #    NUGET_PACKAGE_LOCATION
+#    FBN_BASE_API_URL
+
+#  Possible Application Names. Application name is used to retrieve the correct endpoint.
+#  Underscores can be used in place of dashes
+#  lusid
+#  honeycomb
+#  lusid-identity
+#  lusid-access
+#  drive
+#  notifications
+#  scheduler2
+#  insights
+#  configuration
+
 
 export PACKAGE_NAME               := `echo ${PACKAGE_NAME:-Lusid.Sdk}`
 export PROJECT_NAME               := `echo ${PROJECT_NAME:-Lusid.Sdk}`
 export ASSEMBLY_VERSION           := `echo ${ASSEMBLY_VERSION:-2.0.0}`
 export PACKAGE_VERSION            := `echo ${PACKAGE_VERSION:-2.9999.0-alpha.nupkg}`
-export APPLICATION_NAME           := `echo ${APPLICATION_NAME:-lusid}`
+export APPLICATION_NAME           := `echo ${APPLICATION_NAME:-lusid_identity}`
 export META_REQUEST_ID_HEADER_KEY := `echo ${META_REQUEST_ID_HEADER_KEY:-lusid-meta-requestid}`
 export NUGET_PACKAGE_LOCATION     := `echo ${NUGET_PACKAGE_LOCATION:-~/.nuget/local-packages}`
 
@@ -117,6 +131,7 @@ generate-and-publish-cicd OUT_DIR:
     @just publish-cicd {{OUT_DIR}}
 
 test-local:
+    @just generate-local
     docker run \
         -e PROJECT_NAME=${PROJECT_NAME} \
         -e FBN_API_TEST_APP_NAME=${APPLICATION_NAME} \
@@ -126,7 +141,15 @@ test-local:
         -e FBN_USERNAME=${FBN_USERNAME} \
         -e FBN_CLIENT_ID=${FBN_CLIENT_ID} \
         -e FBN_CLIENT_SECRET=${FBN_CLIENT_SECRET} \
-        -e FBN_LUSID_API_URL=${FBN_LUSID_API_URL} \
+        -e FBN_LUSID_API_URL=${FBN_BASE_API_URL}/api \
+        -e FBN_LUMI_API_URL=${FBN_BASE_API_URL}/honeycomb \
+        -e FBN_LUSID_IDENTITY_API_URL=${FBN_BASE_API_URL}/identity \
+        -e FBN_LUSID_ACCESS_API_URL=${FBN_BASE_API_URL}/access \
+        -e FBN_DRIVE_API_URL=${FBN_BASE_API_URL}/drive \
+        -e FBN_NOTIFICATIONS_API_URL=${FBN_BASE_API_URL}/notifications \
+        -e FBN_SCHEDULER_API_URL=${FBN_BASE_API_URL}/scheduler2 \
+        -e FBN_INSIGHTS_API_URL=${FBN_BASE_API_URL}/insights \
+        -e FBN_CONFIGURATION_API_URL=${FBN_BASE_API_URL}/configuration \
         -e FBN_APP_NAME=${FBN_APP_NAME} \
         -e FBN_PASSWORD=${FBN_PASSWORD} \
         -w /usr/src/tests \

--- a/tests/Tests/Unit/ApiConfigurationBuilderTest.cs
+++ b/tests/Tests/Unit/ApiConfigurationBuilderTest.cs
@@ -11,6 +11,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
     public class ApiConfigurationBuilderTest
     {
         private readonly string APP = Environment.GetEnvironmentVariable("FBN_API_TEST_APP_NAME").ToUpper();
+        private readonly string AppUrlName = $"{Environment.GetEnvironmentVariable("FBN_API_TEST_APP_NAME").ToLower()}Url";
         private string _secretsFile;
         private string _cachedTokenUrl;
         private string _cachedBaseUrl;
@@ -84,7 +85,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
                 {"password", "<password>"},
                 {"clientId", "<clientId>"},
                 {"clientSecret", "<clientSecret>"},
-                {"lusidUrl", string.Format("<{0}Url>", "test")},
+                {AppUrlName, string.Format("<{0}Url>", "test")},
             });
             var apiConfiguration = ApiConfigurationBuilder.Build(_secretsFile);
             Assert.That(apiConfiguration.TokenUrl, Is.EqualTo("<tokenUrl>"));
@@ -105,7 +106,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
                 {"password", "<password>"},
                 // {"clientId", "<clientId>"},
                 {"clientSecret", "<clientSecret>"},
-                {"lusidUrl", string.Format("<{0}Url>", "test")},
+                {AppUrlName, string.Format("<{0}Url>", "test")},
             });
             var exception = Assert.Throws<MissingConfigException>(() => ApiConfigurationBuilder.Build(_secretsFile));
             Assert.That(exception.Message,
@@ -158,7 +159,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             var settings = new Dictionary<string, string>
             {
                 { "api:TokenUrl", "<tokenUrl>" },
-                { "api:LusidUrl", string.Format("<env.{0}Url>", "test") },
+                { $"api:{AppUrlName}", string.Format("<env.{0}Url>", "test") },
                 { "api:ClientId", "<clientId>" },
                 { "api:ClientSecret", "<clientSecret>" },
                 { "api:Username", "<username>" },
@@ -191,7 +192,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             var settings = new Dictionary<string, string>
             {
                 { "api:TokenUrl", "<tokenUrl>" },
-                { "api:LusidUrl", string.Format("<{0}Url>", "test") },
+                { $"api:{AppUrlName}", string.Format("<{0}Url>", "test") },
                 { "api:ClientId", "<clientId>" },
                 { "api:ClientSecret", "" },
                 { "api:Username", "<username>" },

--- a/tests/Tests/Unit/ApiConfigurationTest.cs
+++ b/tests/Tests/Unit/ApiConfigurationTest.cs
@@ -7,6 +7,9 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
     [TestFixture]
     public class ApiConfigurationTest
     {
+
+        private readonly string AppUrlName = $"{Environment.GetEnvironmentVariable("FBN_API_TEST_APP_NAME").ToLower()}Url";
+
         [Test]
         public void ApiConfiguration_HasMissingConfig_Missing_TokenUrl_Returns_True()
         {
@@ -111,7 +114,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             config.BaseUrl = String.Empty;
             List<string> missingList = config.GetMissingConfig();
             Assert.That(missingList.Count, Is.EqualTo(1), "GetMissingConfig list contains one item");
-            Assert.That(missingList[0], Is.EqualTo("lusidUrl"), "GetMissingConfig list string correct");
+            Assert.That(missingList[0], Is.EqualTo(AppUrlName), "GetMissingConfig list string correct");
         }
 
         [Test]

--- a/tests/Tests/Unit/ApiFactoryBuilderTest.cs
+++ b/tests/Tests/Unit/ApiFactoryBuilderTest.cs
@@ -2,12 +2,14 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System;
 
 namespace Finbourne.Sdk.Extensions.Tests.Unit
 {
     [TestFixture]
     public class ApiFactoryBuilderTest
     {
+        private readonly string AppUrlName = $"{Environment.GetEnvironmentVariable("FBN_API_TEST_APP_NAME").ToLower()}Url";
         private string _secretsFile;
         [OneTimeSetUp]
         public void CreateDummySecretsFile()
@@ -17,7 +19,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             {
                 ["api"] = new Dictionary<string, string>()
                 {
-                    {"lusidUrl", "https://sub-domain.lusid.com/api"},
+                    {AppUrlName, "https://sub-domain.lusid.com/api"},
                     {"tokenUrl", "https://sub-domain.okta.com/oauth2/abcd123/v1/token"},
                     {"clientId", "<clientId>"},
                     {"clientSecret", "<clientSecret>"},

--- a/tests/Tests/Unit/ClientCredentialsFlowTokenProviderTest.cs
+++ b/tests/Tests/Unit/ClientCredentialsFlowTokenProviderTest.cs
@@ -2,12 +2,15 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System;
 
 namespace Finbourne.Sdk.Extensions.Tests.Unit
 {
     [TestFixture]
     public class ClientCredentialsFlowTokenProviderTest
     {
+        private readonly string AppUrlName = $"{Environment.GetEnvironmentVariable("FBN_API_TEST_APP_NAME").ToLower()}Url";
+
         [Test]
         public void Constructor_NonNull_Instance_Returned()
         {
@@ -16,7 +19,7 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             {
                 ["api"] = new Dictionary<string, string>()
                 {
-                    {"lusidUrl", "https://sub-domain.lusid.com/api"},
+                    {AppUrlName, "https://sub-domain.lusid.com/api"},
                     {"tokenUrl", "https://sub-domain.okta.com/oauth2/abcd123/v1/token"},
                     {"clientId", "<clientId>"},
                     {"clientSecret", "<clientSecret>"},


### PR DESCRIPTION
Updated tests to work with other project names

# Description of the PR
Updated the ApiConfigurationBuilder to work with dashes and underscores in the environment variables and secrets variables. Updated tests to work with other project names instead of just lucid
