### PR TITLE
CTOOLS-33: Updated client factory to accept custom headers and timeout

### DIFF
--- a/generate/templates/other/ApiFactory.mustache
+++ b/generate/templates/other/ApiFactory.mustache
@@ -91,6 +91,29 @@ namespace {{packageName}}.Extensions
             _apis = Init(configuration);
         }
 
+        /// <summary>
+        /// Create a new factory using the specified configuration
+        /// </summary>
+        /// <param name="configuration">A set of configuration settings</param>
+        /// <param name="headers">Optional: A Dictionary of headers</param>
+        /// <param name="timeout">Optional: Specify the timeout duration in milliseconds. Defaults to 100,000 milliseconds (100 seconds)</param>
+        public ApiFactory(Client.Configuration configuration, IDictionary<string, string>? headers, int? timeout)
+        {
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+
+            if(headers != null || headers.Count > 0)
+            {
+                foreach(var header in headers)
+                {
+                    configuration.DefaultHeaders.Add(header.Key, header.Value);
+                }
+            }
+            configuration.MergeWithGlobalConfiguration();
+
+            _apis = Init(configuration);
+
+        }
+
         /// <inheritdoc />
         public TApi Api<TApi>() where TApi : class, IApiAccessor
         {

--- a/generate/templates/other/ApiFactoryBuilder.mustache
+++ b/generate/templates/other/ApiFactoryBuilder.mustache
@@ -1,5 +1,8 @@
 {{>partial_header}}
 
+using System;
+using System.Collections.Generic;
+
 namespace {{packageName}}.Extensions
 {
     /// <summary>
@@ -30,6 +33,22 @@ namespace {{packageName}}.Extensions
             };
 
             return new ApiFactory(config);
+        }
+
+        /// <summary>
+        /// Create an IApiFactory using the specified Url, Token Provider, optional headers and timeout
+        /// </summary>
+        public static IApiFactory Build(string url, ITokenProvider tokenProvider, IDictionary<string, string>? headers, int? timeout = 100000)
+        {
+            // TokenProviderConfiguration.ApiClient is the client used by ApiFactory and is 
+            // NOT thread-safe, so there needs to be a separate instance for each instance of ApiFactory.
+            // Do NOT cache the ApiFactory instances (DEV-6922)
+            var config = new TokenProviderConfiguration(tokenProvider)
+            {
+                BasePath = url
+            };
+
+            return new ApiFactory(config, headers, timeout);
         }
     }
 }

--- a/tests/Tests/Unit/ApiFactoryBuilderTest.cs
+++ b/tests/Tests/Unit/ApiFactoryBuilderTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System;
+using Lusid.Sdk.Api;
 
 namespace Finbourne.Sdk.Extensions.Tests.Unit
 {
@@ -50,6 +51,22 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             };
             var apiFactory = new ApiFactory(config);
             Assert.IsNotNull(apiFactory);
+        }
+
+        [Test]
+        public void Custom_Builder_Parameters()
+        {
+            var config = new TokenProviderConfiguration(new ClientCredentialsFlowTokenProvider(ApiConfigurationBuilder.Build(_secretsFile)))
+            {
+                BasePath = "base path"
+            };
+            string key = "header_key";
+            var testHeaders = new Dictionary<string, string>() {{key, "testApp"}};
+            int timeOut = 50;
+            var apiFactory = new ApiFactory(config, testHeaders, timeOut);
+
+            Assert.IsNotNull(apiFactory);
+            Assert.That(apiFactory.Api<ApplicationMetadataApi>().Configuration.DefaultHeaders, Does.ContainKey(key));
         }
     }
 }

--- a/tests/Tests/Unit/ApiFactoryTest.cs
+++ b/tests/Tests/Unit/ApiFactoryTest.cs
@@ -1,6 +1,7 @@
 using Lusid.Sdk.Api;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 
 namespace Finbourne.Sdk.Extensions.Tests.Unit
 {
@@ -59,6 +60,19 @@ namespace Finbourne.Sdk.Extensions.Tests.Unit
             var apiFactory = new ApiFactory(apiConfig);
             Assert.That(apiFactory.Api<ApplicationMetadataApi>().Configuration.DefaultHeaders, Does.ContainKey("X-LUSID-Application"));
             Assert.AreEqual(appName, apiFactory.Api<ApplicationMetadataApi>().Configuration.DefaultHeaders["X-LUSID-Application"]);
+        }
+
+        [Test]
+        public void HeadersProvided()
+        {
+            string key = "key_name";
+            var config = new TokenProviderConfiguration(null);
+           
+            var testHeaders = new Dictionary<string, string>() {{key, "testHeader"}};
+            int timeOut = 3000;
+            var apiFactory = new ApiFactory(config, testHeaders, timeOut);
+            Assert.That(apiFactory.Api<ApplicationMetadataApi>().Configuration.DefaultHeaders, Does.ContainKey(key));
+
         }
     }
 }


### PR DESCRIPTION
# Description of the PR

Updated the ApiFactory and ApiFactoryBuilder to accept custom headers and timeout.
Added tests to test these new additions
